### PR TITLE
Update virtualbox.yml

### DIFF
--- a/tasks/virtualbox.yml
+++ b/tasks/virtualbox.yml
@@ -24,5 +24,5 @@
 
 - name: Delete VirtualBox guest additions ISO.
   file:
-    src: "/home/vagrant/VBoxGuestAdditions_{{ virtualbox_version.stdout }}.iso"
+    path: "/home/vagrant/VBoxGuestAdditions_{{ virtualbox_version.stdout }}.iso"
     state: absent


### PR DESCRIPTION
Argument path is required in the task "Delete VirtualBox guest additions ISO"
From logs
    virtualbox-iso: TASK [geerlingguy.packer-rhel : Delete VirtualBox guest additions ISO.] ********
    virtualbox-iso: fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "missing required arguments: path"}