### PR TITLE
Supress "Consider using yum module" warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,10 +92,19 @@
   notify: yum-clean-all
 
 - name: Remove any remnants of VirtualBox ISOs.
-  shell: rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
+- find:
+    paths: "{{ playbook_dir }}"
+    patterns: "VBoxGuestAdditions_*.iso*"
+   register: find_results
+- file:
+    path: "{{ item['path'] }}"
+    state: absent
+  with_items: "{{ find_results['files'] }}"
 
 - name: Remove RedHat interface persistence (step 1).
-  shell: rm -f /etc/udev/rules.d/70-persistent-net.rules
+- file:
+   path: /etc/udev/rules.d/70-persistent-net.rules
+   state: absent
 
 - name: Remove RedHat interface persistence (step 2).
   lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
 - name: Remove any remnants of VirtualBox ISOs.
 - find:
     paths: "{{ playbook_dir }}"
-    patterns: "VBoxGuestAdditions_*.iso*"
+    patterns: 'VBoxGuestAdditions_*.iso,VBoxGuestAdditions_*.iso.?'
    register: find_results
 - file:
     path: "{{ item['path'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,16 +76,20 @@
 - include_tasks: vmware.yml
   when: vmware_check.rc == 0
 
-# Cleanup tasks.
+# Handler for 'yum clean all' command whichs in effect runs yum clean packages and yum clean headers
+- name: yum-clean-all
+  command: yum clean all
+  args:
+    warn: no
+
+# Cleanup tasks
 - name: Remove unneeded packages.
   yum: "name={{ item }} state=absent"
   with_items:
     - cpp
     - kernel-devel
     - kernel-headers
-
-- name: Clean up yum.
-  command: yum clean all
+  notify: yum-clean-all
 
 - name: Remove any remnants of VirtualBox ISOs.
   shell: rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?


### PR DESCRIPTION
    : TASK [geerlingguy.packer-rhel : Clean up yum.] *********************************
    :  [WARNING]: Consider using yum module rather than running yum

To suppress this warning, a workaround can be applied via a notification handler as per documentation[1]. Reasoning for specific s/workaround/hack/ can be found in the last comment of PR[2].

[1] https://docs.ansible.com/ansible/latest/modules/yum_repository_module.html
[2] https://github.com/ansible/ansible/pull/31450