### PR TITLE
Remove missing key so role doesn't fail with 404 error

### DIFF
--- a/tasks/vmware.yml
+++ b/tasks/vmware.yml
@@ -9,7 +9,6 @@
     key: "{{ item }}"
     state: present
   with_items:
-    - "http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-DSA-KEY.pub"
     - "http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub"
 
 - name: Add vmhgfs module (RHEL 6).


### PR DESCRIPTION
Minimal fix, just removed the file that no longer exists on VMware's site