### PR TITLE
 Adding role_name property.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,8 +3,9 @@ dependencies: []
 
 galaxy_info:
   role_name: packer_rhel
-  author: olidrouin
+  author: geerlingguy
   description: RedHat/CentOS configuration for Packer.
+  company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 2.4
   platforms:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,9 +3,8 @@ dependencies: []
 
 galaxy_info:
   role_name: packer_rhel
-  author: geerlingguy
+  author: olidrouin
   description: RedHat/CentOS configuration for Packer.
-  company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 2.4
   platforms:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@
 dependencies: []
 
 galaxy_info:
+  role_name: packer_rhel
   author: olidrouin
   description: RedHat/CentOS configuration for Packer.
   license: "license (BSD, MIT)"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,9 +2,8 @@
 dependencies: []
 
 galaxy_info:
-  author: geerlingguy
+  author: olidrouin
   description: RedHat/CentOS configuration for Packer.
-  company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 2.4
   platforms:


### PR DESCRIPTION

Adding role_name property. Galaxy doesn't remove "ansible-role-" anymore. See https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names