### PR TITLE
 conditionals to int comparisons (rhel8+ support)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,10 @@
   changed_when: false
   register: kernel_release
 
-- name: Set the appropriate libselinux package for RHEL 8.
+- name: Set the appropriate libselinux package for RHEL 8+.
   set_fact:
     packer_rhel_libselinux_package: python3-libselinux
-  when: ansible_facts.distribution_major_version == '8'
+  when: ansible_facts.distribution_major_version | int >= 8
 
 - name: Ensure necessary packages are installed.
   yum:
@@ -36,7 +36,7 @@
 
 - name: Restart network service (RHEL < 8).
   service: name=network state=restarted
-  when: ansible_facts.distribution_major_version < '8'
+  when: ansible_facts.distribution_major_version | int < 8
 
 # SSH daemon configuration.
 - name: Configure SSH daemon.


### PR DESCRIPTION
- convert distribution_major_version to int before compair fixing bad
  string compairs (ie '10' < '8' == true)
- set RHEL 8+ to use python3-libselinux
